### PR TITLE
Enable incremental annotation processing for Gradle 5.4+

### DIFF
--- a/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,0 +1,1 @@
+net.nicoulaj.compilecommand.CompileCommandProcessor,isolating


### PR DESCRIPTION
Gradle now supports incremental compilation by default and has support for incremental annotation processing. The latter was limited in the past (before Gradle 5.4), because apts that use `Filer#createResource` always triggered a full recompilation. This limitation was removed in Gradle 5.4, so that compile-command-annotations can benefit from it.

The change is rather simple, just requires a file in `META-INF` with the right declaration.

The change in the `pom.xml` was due to `net.nicoulaj:parent:57` having a reference to a no longer existing version of the surefire plugin, and `net.nicoulaj:parent:58` hasn't been released yet.

References:
* [New in Gradle 5](https://gradle.org/whats-new/gradle-5/)
* [Incremental annotation processing](https://docs.gradle.org/5.0/userguide/java_plugin.html#sec:incremental_annotation_processing)
* [Gradle PR to support incremental annotation processing for `Filer#createResource` since Gradle 5.4](https://github.com/gradle/gradle/pull/8797)